### PR TITLE
Refactor: corrige error on click dentro de li

### DIFF
--- a/src/ui/views/Home/_components/Item/Item.module.scss
+++ b/src/ui/views/Home/_components/Item/Item.module.scss
@@ -11,6 +11,8 @@
     height: auto; 
     margin: 0 auto; 
     padding: 10px; 
+    text-decoration: none;
+    color: inherit;
 }
 
 .itemImage {

--- a/src/ui/views/Home/_components/Item/Item.tsx
+++ b/src/ui/views/Home/_components/Item/Item.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import {
   type Product,
   getFormattedPrice,
@@ -8,12 +8,12 @@ import { getProductDetailRoute } from "../../../../../core/constants/routeConsta
 import { useCallback } from "react";
 export const Item = ({ product }: { product: Product }) => {
   const navigate = useNavigate();
-  const handleItemClick = useCallback(() => {
+  useCallback(() => {
     navigate(getProductDetailRoute(product.id));
   }, [navigate, product.id]);
   return (
-    <li onClick={handleItemClick}>
-      <div className={styles.item}>
+    <li>
+      <Link to={getProductDetailRoute(product.id)} className={styles.item}>
         <img
           className={styles.itemImage}
           src={product.imgUrl}
@@ -21,7 +21,7 @@ export const Item = ({ product }: { product: Product }) => {
         />
         <h3>{product.name}</h3>
         <p>{getFormattedPrice(product)}</p>
-      </div>
+      </Link>
     </li>
   );
 };


### PR DESCRIPTION
### Qué hace
Elimina el elemento onClick dentro de un "li" al no ser correcto y lo aplica en un link.

### Cómo probarla
Lanzar la aplicación al clickar en un item debería llevarnos al detalle del producto que hayamos clickado.
Comprobar que se con los ajustes realizados no se aplican los estilos genéricos de los Links